### PR TITLE
FAU_GEN consistency

### DIFF
--- a/input/wlanclient.xml
+++ b/input/wlanclient.xml
@@ -667,7 +667,7 @@
             </h:b> to generate an audit record of the following auditable events:
                  <h:ol type="a">
                 <h:li>Startup and shutdown of the audit functions;</h:li>
-                <h:li>All auditable events for [<h:i>not specified</h:i>] level of audit; and</h:li>
+                <h:li>All auditable events for [<h:i>not selected</h:i>] level of audit; and</h:li>
                 <h:li>[<h:i>all auditable events for mandatory SFRs specified in <xref g="t-audit-mandatory"/> and 
 					selected SFRs in <xref g="t-audit-sel-based"/></h:i>].</h:li>
               </h:ol>


### PR DESCRIPTION
The Bluetooth and MDF PPs both use "not selected" level of audit, but WLAN uses "not specified". Technically I think "not specified" makes more sense, but this is one change instead of 2 (could be just as well to change it in MDF v3.3 and then in the BT, don't really care).